### PR TITLE
Add support for Traditional Chinese and Japanese, improve language matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ This extension currently supports the following interface languages:
 - **English**
 - **Spanish**
 - **French**
+- **Traditional chinese**
+- **Japanese**
 
 If you use X in another language and want the extension to work for you too, you can help!
 <br />Open a [Pull Request](https://github.com/alterebro/bye-for-you/pulls) or [Issue](https://github.com/alterebro/bye-for-you/issues) with the translations used for the "For You" and "Following" tabs, including the language code:

--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -4,16 +4,22 @@
 		'es': { forYou: 'Para ti', following: 'Siguiendo' },
 		'fr': { forYou: 'Pour vous', following: 'Abonnements' },
 		'pt': { forYou: 'Para você', following: 'Seguindo' },
+		'zh-hant': { forYou: '為你推薦', following: '正在跟隨' },
+		'zh-tw': { forYou: '為你推薦', following: '正在跟隨' },
+		'zh': { forYou: '為你推薦', following: '正在跟隨' },
+		'ja': { forYou: 'おすすめ', following: 'フォロー中' }
 	};
 
 	const getLanguage = () => {
 		const lang = document.documentElement.lang || navigator.language || 'en';
-		return lang.split('-')[0]; 
+		return lang.toLowerCase();
 	};
 
 	const getLabels = () => {
-		const langCode = getLanguage();
-		return LANG_MAP[langCode] || LANG_MAP['en'];
+		const fullLang = getLanguage();
+		const baseLang = fullLang.split('-')[0];
+
+		return LANG_MAP[fullLang] || LANG_MAP[baseLang] || LANG_MAP['en'];
 	};
 
 	const removeForYouAndSelectFollowing = () => {


### PR DESCRIPTION
Hello! Thank you for creating this useful extension. 🙌

I would like to contribute by adding support for **Traditional Chinese** and **Japanese** interfaces, as mentioned in the README. 

### Changes made:
1. **Added Translations:**
   - Traditional Chinese (`zh-hant`, `zh-tw`, `zh`): `為你推薦` / `正在跟隨`
   - Japanese (`ja`): `おすすめ` / `フォロー中`

2. **Improved Language Matching Logic:**
   - Updated `getLanguage()` and `getLabels()` to support full language codes (e.g., `zh-hant` or `ja-jp`). 
   - Previously, the code only checked the base language (`split('-')[0]`). However, for languages like Traditional Chinese, the specific regional/script subtag is required to apply the correct translation.
   - The updated logic first checks for an exact match of the full language code, then falls back to the base language code, and finally defaults to English if no match is found.